### PR TITLE
商品出品ページの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+public/uploads/*

--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,6 @@ end
 gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem "font-awesome-sass"
 gem 'devise'
+gem 'active_hash'
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.4)
       activesupport (= 6.0.3.4)
       globalid (>= 0.3.6)
@@ -92,6 +94,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -125,6 +134,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
     kgio (2.11.3)
@@ -141,6 +153,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -200,6 +213,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
@@ -275,6 +290,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.2)
   byebug
   capistrano
@@ -284,11 +300,13 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)
+  carrierwave
   devise
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,4 +11,4 @@
 @import "modules/user";
 @import "font-awesome";
 @import "modules/footer";
-
+@import "modules/new";

--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -1,0 +1,122 @@
+.Listing {
+  background-color:#f5f5f5;
+  width: 100vw;
+  height: 100%;
+  overflow: scroll;
+  .TopIcon {
+    text-align: center;
+    padding: 50px 0;
+    &__icon {
+    width: 200px;
+    }
+  }
+  .Content {
+    height: 100％;
+    width: 700px;
+    background-color: #ffffff;
+    padding: 40px;
+    margin: 0 auto;
+    border-bottom: 1px dotted #dcdcdc;
+    &__title {
+      display: flex;
+      margin-bottom: 30px;
+      &__name {
+        font-size: 18px;
+        font-weight: 600;
+      }
+      &__Atag {
+        margin-left: 8px;
+        background-color: #3ccace;
+        color: #ffffff;
+        font-size: 16px;
+        padding: 2px 6px;
+        font-weight: 600;
+        border-radius: 5px;
+      }
+      &__Btag {
+        margin-left: 8px;
+        background-color: gray;
+        color: #ffffff;
+        font-size: 16px;
+        padding: 2px 6px;
+        font-weight: 600;
+        border-radius: 5px;
+      }
+    }
+    &__Image {
+      width: 100%;
+      height: 200px;
+      margin: 10px auto 50px;
+      border: 1px dashed ;
+      border-radius: 2px;
+      background-color:#f5f5f5;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      &__Form{
+        &__Icon {
+          width: 50px;
+          height: 50px;
+        }
+        &__tag {
+          display: none;
+        }
+        &__box {
+           height: 120px;
+           width: 120px;
+         }
+      }
+    }
+    &__AField {
+      width: 100%;
+      height: 50px;
+      margin: 20px auto 50px;
+    }
+    &__BField {
+      width: 100%;
+      height: 200px;
+      margin: 20px auto 50px;
+    }
+    &__CField {
+      width: 50%;
+      height: 50px;
+      margin: 20px auto 50px;
+    }
+  }
+  .Send {
+    height: 100％;
+    width: 700px;
+    background-color: #ffffff;
+    padding: 40px;
+    margin: 0 auto;
+    &__ABtn {
+      background-color: #3ccace;
+      color: #ffffff;
+      border-radius: 5px;
+      height: 60px;
+      width: 400px;
+      border: none;
+      margin: 30px auto;
+      display: block; 
+    }
+    .ReturnBtn {
+      text-align: center;
+      margin-bottom: 50px;
+    }
+    a {
+      text-decoration: none;
+      color: #3ccace;
+    }
+  }
+  .footer {
+    display: flex;
+    justify-content: center;
+    height: 200px;
+    &__Icon {
+      margin-top: 100px;
+      &__tag {
+        width: 180px;
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
   def index
   end
+
+  def new
+  end
 end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,0 +1,21 @@
+class Area < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end
+

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,6 @@
+class Condition < ActiveHash::Base
+  self.data = [
+    {id: 1, name: '新品、未使用'}, {id: 2, name: '未使用に近い'}, {id: 3, name: '目立った傷や汚れなし'},
+    {id: 4, name: 'やや傷や汚れあり'}, {id: 5, name: '傷や汚れあり'}, {id: 6, name: '全体的に状態が悪い'}
+   ]
+end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,0 +1,5 @@
+class Day < ActiveHash::Base
+  self.data = [ 
+    {id: 1, day: '支払い後、1~2日で発送'}, {id: 2, day: '支払い後、2~3日で発送'}, {id: 3, day: '支払い後、4~7日で発送'}
+  ]
+end

--- a/app/models/shipping_cost.rb
+++ b/app/models/shipping_cost.rb
@@ -1,0 +1,5 @@
+class ShippingCost < ActiveHash::Base
+  self.data = [
+    {id: 1, status: '送料込み(出品者負担)'}, {id: 2, status: '着払い(購入者負担)'}
+   ]
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  process resize_to_fit: [200, 200]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,0 +1,65 @@
+.Listing
+  .TopIcon
+    = image_tag '/assets/logo/logo.png', alt: '', class: 'TopIcon__icon'
+  = form_for new_item_path, method: :post, local: true do |f|
+    .Content
+      .Content__title
+        %label.Content__title__name 出品画像
+        %span.Content__title__Atag 必須
+      %p.Content__text 最大5枚までアップロードできます
+      .Content__Image
+        .Content__Image__Form
+          = f.label :image do
+            = image_tag src= "icon/icon_camera.png", class: "Content__Image__Form__Icon"
+            = f.file_field :image, class: "Content__Image__Form__tag"
+            %input{class:"Content__Image__Form__tag", type: "file"}
+            %input{class:"Content__Image__Form__tag", type: "file"}
+            %input{class:"Content__Image__Form__tag", type: "file"}
+            %input{class:"Content__Image__Form__tag", type: "file"}
+            %input{class:"Content__Image__Form__tag", type: "file"}
+            %input{class:"Content__Image__Form__tag", type: "file"}
+    .Content
+      .Content__title
+        %label.Content__title__name 商品名
+        %span.Content__title__Atag 必須
+      = f.text_field :name, placeholder: "40文字まで", class: "Content__AField"
+      .Content__title
+        %label.Content__title__name 商品の説明
+        %span.Content__title__Atag 必須
+      = f.text_area :content, placeholder: '商品の説明', class: "Content__BField"
+    .Content
+      .Content__title
+        %label.Content__title__name カテゴリー
+        %span.Content__title__Atag 必須
+      = f.text_field :name, placeholder: "", class: "Content__AField"
+      .Content__title
+        %label.Content__title__name ブランド
+        %span.Content__title__Btag 任意
+      = f.text_field :name, placeholder: "例）シャネル", class: "Content__AField"
+      .Content__title
+        %label.Content__title__name 商品の状態
+        %span.Content__title__Atag 必須
+      = f.collection_select(:condition_id, Condition.all, :id, :name,{include_blank: "選択してください"}, class: "Content__AField" )
+    .Content
+      .Content__title
+        %label.Content__title__name 配送料の負担
+        %span.Content__title__Atag 必須
+      = f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :status,{include_blank: "選択してください"}, class: "Content__AField" )
+      .Content__title
+        %label.Content__title__name 発送元の地域
+        %span.Content__title__Atag 必須
+      = f.collection_select(:area_id, Area.all, :id, :name,{include_blank: "選択してください"}, class: "Content__AField" )
+      .Content__title
+        %label.Content__title__name 発送までの日数
+        %span.Content__title__Atag 必須
+      = f.collection_select(:day_id, Day.all, :id, :day,{include_blank: "選択してください"}, class: "Content__AField" )
+    .Content
+      .Content__title
+        %label.Content__title__name 販売価格
+        %span.Content__title__Atag 必須
+      = f.text_field :name, placeholder: "¥300 ~ 2,000,000", class: "Content__CField"
+    .Send
+      = f.submit '出品する', class: 'Send__ABtn'
+      .ReturnBtn
+        = link_to'もどる'
+ 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
+  resources :items, only: [:index, :new]
   devise_scope :users do
     get '/users', to: redirect("/users/sign_up")
   end


### PR DESCRIPTION
#what
・出品する商品の情報を入力するフォームの作成
・複数の画像のアップロード
・collection_selectを使用してテーブルの情報を選択できる

#why
フリマアプリの根幹となる商品出品のフロントの作成
