### PR TITLE
商品情報編集のカテゴリー表示

### DIFF
--- a/app/assets/stylesheets/modules/new.scss
+++ b/app/assets/stylesheets/modules/new.scss
@@ -97,7 +97,7 @@
     &__AField {
       width: 100%;
       height: 50px;
-      margin: 20px auto 50px;
+      margin: 0 auto 30px;
     }
     &__BField {
       width: 100%;

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -46,8 +46,8 @@
         %label.Content__title__name カテゴリー
         %span.Content__title__Atag 必須
       = f.collection_select :category_id, @parents, :id, :name, {prompt: "選択して下さい", selected: @item.category.root_id}, {class: "Content__AField", id: "category_select"}
-      = f.collection_select :category_id, @item.category.parent.siblings, :id, :name, {prompt: "選択して下さい", selected: @item.category.parent}, {class: "Content__AField"}
-      = f.collection_select :category_id, @item.category.siblings, :id, :name, {prompt: "選択して下さい"}, {class: "Content__AField"}
+      = f.collection_select :category_id, @item.category.parent.siblings, :id, :name, {prompt: "選択して下さい", selected: @item.category.parent}, {class: "Content__AField", id: "children_categories"}
+      = f.collection_select :category_id, @item.category.siblings, :id, :name, {prompt: "選択して下さい"}, {class: "Content__AField", id: "grandchildren_categories"}
       .Content__title
         %label.Content__title__name ブランド
         %span.Content__title__Btag 任意

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -45,7 +45,9 @@
       .Content__title
         %label.Content__title__name カテゴリー
         %span.Content__title__Atag 必須
-      = f.collection_select :category_id, @parents, :id, :name, {prompt: "選択して下さい"}, {class: "Content__AField", id: "category_select"}
+      = f.collection_select :category_id, @parents, :id, :name, {prompt: "選択して下さい", selected: @item.category.root_id}, {class: "Content__AField", id: "category_select"}
+      = f.collection_select :category_id, @item.category.parent.siblings, :id, :name, {prompt: "選択して下さい", selected: @item.category.parent}, {class: "Content__AField"}
+      = f.collection_select :category_id, @item.category.siblings, :id, :name, {prompt: "選択して下さい"}, {class: "Content__AField"}
       .Content__title
         %label.Content__title__name ブランド
         %span.Content__title__Btag 任意

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,6 +1,7 @@
 .Listing
   .TopIcon
-    = image_tag src='/assets/logo/logo.png', alt: '', class: 'TopIcon__icon'
+    = link_to '/', class:'' do
+      = image_tag 'logo/logo.png', alt: '', class: 'TopIcon__icon'
   = form_for @item, method: :put, local: true do |f| 
     .Content
       - if f.object.errors.full_messages.length != 0


### PR DESCRIPTION
#What
商品情報の編集時、カテゴリーも現状の商品情報が表示及び再選択ができるようにした。

#Why
カテゴリーはAncestryを使用しており、親子孫まで表示させる記述が必要のため。